### PR TITLE
追加：アジェンダ削除機能

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -20,6 +20,18 @@ class AgendasController < ApplicationController
       render :new
     end
   end
+
+  def destroy
+    if @agenda.user_id == current_user.id || @agenda.team.owner_id == current_user.id
+      @agenda.destroy
+      notice_members = @agenda.team.assigns.map(&:user)
+      DeleteAgendaMailer.delete_agenda_notice_mail(notice_members).deliver
+      redirect_to dashboard_url, notice: I18n.t('views.messages.success_agenda_destroy')
+    else
+      redirect_to team_path(@agenda.team.id), notice: I18n.t('views.messages.fail_agenda_destroy')
+    end    
+  end
+  
 
   private
 

--- a/app/mailers/delete_agenda_mailer.rb
+++ b/app/mailers/delete_agenda_mailer.rb
@@ -1,0 +1,6 @@
+class DeleteAgendaMailer < ApplicationMailer
+  def delete_agenda_notice_mail(notice_members)
+    @notice_members = notice_members
+    mail to: @notice_members.map(&:email), subject: I18n.t('views.messages.success_agenda_destroy')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,3 +27,7 @@ class User < ApplicationRecord
     SecureRandom.hex(10)
   end
 end
+
+def owner?(team)
+  self.id == team.owner_id
+end

--- a/app/views/delete_agenda_mailer/delete_agenda_notice_mail.html.erb
+++ b/app/views/delete_agenda_mailer/delete_agenda_notice_mail.html.erb
@@ -1,0 +1,1 @@
+<h2><%= I18n.t('views.messages.success_agenda_destroy') %></h2>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,6 +37,9 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <% if agenda.user_id == current_user.id || agenda.team.owner_id == current_user.id %>
+              <%= link_to t('views.button.delete'), agenda, method: :delete, data: { confirm: I18n.t('views.messages.confirm_agenda_destroy') }, class: 'nav-link d-inline-flex'%>
+            <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,6 +253,9 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      success_agenda_destroy: "アジェンダを削除しました"
+      fail_agenda_destroy: "アジェンダを削除する権限がありません"
+      confirm_agenda_destroy: "削除してよろしですか？"
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
## issue
#67

## 内容
- AgendasControllerのdestroyアクションを追加し、そこに機能追加する
- Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- Agendaに紐づいているarticleも一緒に削除される
- Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
- 情報処理が完了した後はDashBoardに飛ぶ